### PR TITLE
Fix the aquire->acquire typo

### DIFF
--- a/src/ippusbxd.c
+++ b/src/ippusbxd.c
@@ -61,13 +61,13 @@ static void *service_connection(void *arg_void)
 				ERR_AND_EXIT("Got null packet from tcp");
 			}
 			if (usb == NULL) {
-				usb = usb_conn_aquire(arg->usb_sock, 1);
+				usb = usb_conn_acquire(arg->usb_sock, 1);
 				if (usb == NULL) {
-					ERR("Failed to aquire usb interface");
+					ERR("Failed to acquire usb interface");
 					packet_free(pkt);
 					goto cleanup_subconn;
 				}
-				NOTE("Interface #%d: aquired usb conn",
+				NOTE("Interface #%d: acquired usb conn",
 						usb->interface_index);
 			}
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -195,7 +195,7 @@ found_device:
 	                                      (uint8_t)selected_config,
 	                                      &config);
 	if (status != 0 || config == NULL) {
-		ERR("Failed to aquire config descriptor");
+		ERR("Failed to acquire config descriptor");
 		goto error;
 	}
 
@@ -454,7 +454,7 @@ static int usb_all_conns_staled(struct usb_sock_t *usb)
 	return staled;
 }
 
-struct usb_conn_t *usb_conn_aquire(struct usb_sock_t *usb,
+struct usb_conn_t *usb_conn_acquire(struct usb_sock_t *usb,
                                    int is_high_priority)
 {
 	int used_high_priority = 0;

--- a/src/usb.h
+++ b/src/usb.h
@@ -64,7 +64,7 @@ void usb_close(struct usb_sock_t *);
 int usb_can_callback(struct usb_sock_t *);
 void usb_register_callback(struct usb_sock_t *);
 
-struct usb_conn_t *usb_conn_aquire(struct usb_sock_t *, int);
+struct usb_conn_t *usb_conn_acquire(struct usb_sock_t *, int);
 void usb_conn_release(struct usb_conn_t *);
 
 void usb_conn_packet_send(struct usb_conn_t *, struct http_packet_t *);


### PR DESCRIPTION
Hi Daniel,

Debian's lintian revealed the aquire->acquire typo. This commit fixes it everywhere.

It'd be cool to tag a new version with the few novelties on top of 1.21.2 :-)

Cheers,

OdyX